### PR TITLE
Fix timer and android de-sync

### DIFF
--- a/components/bsb/timer/background/api/build.gradle
+++ b/components/bsb/timer/background/api/build.gradle
@@ -7,6 +7,7 @@ plugins {
 commonDependencies {
     implementation(projects.components.core.data)
     implementation(projects.components.core.log)
+    implementation(projects.components.core.trustedClock.api)
 
     implementation(projects.components.bsb.dao.api)
 

--- a/components/bsb/timer/background/api/src/commonMain/kotlin/com/flipperdevices/bsb/timer/background/api/TimerApi.kt
+++ b/components/bsb/timer/background/api/src/commonMain/kotlin/com/flipperdevices/bsb/timer/background/api/TimerApi.kt
@@ -2,9 +2,12 @@ package com.flipperdevices.bsb.timer.background.api
 
 import com.flipperdevices.bsb.timer.background.model.ControlledTimerState
 import com.flipperdevices.bsb.timer.background.model.TimerTimestamp
+import com.flipperdevices.core.trustedclock.TrustedClock
 import kotlinx.coroutines.flow.StateFlow
 
 interface TimerApi {
+    val trustedClock: TrustedClock
+
     fun setTimestampState(state: TimerTimestamp)
     fun getTimestampState(): StateFlow<TimerTimestamp>
 

--- a/components/bsb/timer/background/api/src/commonMain/kotlin/com/flipperdevices/bsb/timer/background/model/TimerTimestamp.kt
+++ b/components/bsb/timer/background/api/src/commonMain/kotlin/com/flipperdevices/bsb/timer/background/model/TimerTimestamp.kt
@@ -42,9 +42,9 @@ sealed interface TimerTimestamp {
         @SerialName("settings")
         val settings: TimerSettings,
         @SerialName("start")
-        val start: Instant = Clock.System.now(),
+        val start: Instant,
         @SerialName("no_offset_start")
-        val noOffsetStart: Instant = Clock.System.now(),
+        val noOffsetStart: Instant,
         @SerialName("pause")
         val pause: Instant? = null,
         @SerialName("confirm_next_step_click")

--- a/components/bsb/timer/background/impl/build.gradle
+++ b/components/bsb/timer/background/impl/build.gradle
@@ -32,7 +32,6 @@ androidDependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle)
     implementation(libs.kotlin.serialization.json)
-    implementation("com.google.android.gms:play-services-time:16.0.1")
 }
 
 commonTestDependencies {

--- a/components/bsb/timer/background/impl/build.gradle
+++ b/components/bsb/timer/background/impl/build.gradle
@@ -10,6 +10,7 @@ commonDependencies {
     implementation(projects.components.core.ktx)
     implementation(projects.components.core.log)
     implementation(projects.components.core.data)
+    implementation(projects.components.core.trustedClock.api)
 
     implementation(projects.components.bsb.cloudMock)
     implementation(projects.components.bsb.dao.api)
@@ -31,6 +32,7 @@ androidDependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle)
     implementation(libs.kotlin.serialization.json)
+    implementation("com.google.android.gms:play-services-time:16.0.1")
 }
 
 commonTestDependencies {

--- a/components/bsb/timer/background/impl/src/androidMain/kotlin/com/flipperdevices/bsb/timer/background/api/AndroidTimerApi.kt
+++ b/components/bsb/timer/background/impl/src/androidMain/kotlin/com/flipperdevices/bsb/timer/background/api/AndroidTimerApi.kt
@@ -56,8 +56,8 @@ class AndroidTimerApi(
 
     override fun setTimestampState(state: TimerTimestamp) {
         info { "Request start timer via android service timer api" }
+        timerTimestampFlow.update { state }
         if (state is TimerTimestamp.Pending) {
-            timerTimestampFlow.update { state }
             stopTimer()
             return
         }
@@ -70,7 +70,6 @@ class AndroidTimerApi(
         context.startService(intent)
         scope.launch(Dispatchers.IO) {
             withLock(mutex) {
-                timerTimestampFlow.emit(state)
                 if (binderListenerJob == null) {
                     val bindSuccessful = context.bindService(
                         Intent(context, TimerForegroundService::class.java),

--- a/components/bsb/timer/background/impl/src/androidMain/kotlin/com/flipperdevices/bsb/timer/background/api/AndroidTimerApi.kt
+++ b/components/bsb/timer/background/impl/src/androidMain/kotlin/com/flipperdevices/bsb/timer/background/api/AndroidTimerApi.kt
@@ -19,7 +19,6 @@ import com.flipperdevices.core.log.error
 import com.flipperdevices.core.log.info
 import com.flipperdevices.core.trustedclock.TrustedClock
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -31,7 +30,6 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import me.tatarka.inject.annotations.Inject
 import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
@@ -69,7 +67,7 @@ class AndroidTimerApi(
 
         intent.putExtra(EXTRA_KEY_TIMER_STATE, Json.encodeToString(state))
         context.startService(intent)
-        scope.launch(Dispatchers.IO) {
+        scope.launch {
             withLock(mutex) {
                 if (binderListenerJob == null) {
                     val bindSuccessful = context.bindService(

--- a/components/bsb/timer/background/impl/src/androidMain/kotlin/com/flipperdevices/bsb/timer/background/api/AndroidTimerApi.kt
+++ b/components/bsb/timer/background/impl/src/androidMain/kotlin/com/flipperdevices/bsb/timer/background/api/AndroidTimerApi.kt
@@ -85,14 +85,10 @@ class AndroidTimerApi(
 
     private fun stopTimer() {
         timerTimestampFlow.update {
-            when (it) {
-                is TimerTimestamp.Pending -> {
-                    it
-                }
-
-                else -> {
-                    TimerTimestamp.Pending.Finished
-                }
+            if (it is TimerTimestamp.Pending) {
+                it
+            } else {
+                TimerTimestamp.Pending.Finished
             }
         }
         val intent = Intent(context, TimerForegroundService::class.java)

--- a/components/bsb/timer/background/impl/src/androidMain/kotlin/com/flipperdevices/bsb/timer/background/api/AndroidTimerApi.kt
+++ b/components/bsb/timer/background/impl/src/androidMain/kotlin/com/flipperdevices/bsb/timer/background/api/AndroidTimerApi.kt
@@ -15,9 +15,9 @@ import com.flipperdevices.bsb.timer.background.service.TimerServiceBinder
 import com.flipperdevices.core.di.AppGraph
 import com.flipperdevices.core.ktx.common.withLock
 import com.flipperdevices.core.log.LogTagProvider
-import com.flipperdevices.core.log.TaggedLogger
 import com.flipperdevices.core.log.error
 import com.flipperdevices.core.log.info
+import com.flipperdevices.core.trustedclock.TrustedClock
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -43,6 +43,7 @@ import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
 class AndroidTimerApi(
     private val scope: CoroutineScope,
     private val context: Context,
+    override val trustedClock: TrustedClock
 ) : TimerApi, ServiceConnection, LogTagProvider {
     override val TAG = "AndroidTimerApi"
 

--- a/components/bsb/timer/background/impl/src/androidMain/kotlin/com/flipperdevices/bsb/timer/background/service/TimerForegroundService.kt
+++ b/components/bsb/timer/background/impl/src/androidMain/kotlin/com/flipperdevices/bsb/timer/background/service/TimerForegroundService.kt
@@ -47,12 +47,14 @@ class TimerForegroundService : LifecycleService(), LogTagProvider, TimerStateLis
                     state,
                     TimerBroadcastReceiver.getTimerIntents(this@TimerForegroundService)
                 )
-                if (notification == null) {
-                    notificationManager.cancel(ONGOING_NOTIFICATION_ID)
-                } else {
-                    notificationManager.notify(ONGOING_NOTIFICATION_ID, notification)
+                withContext(Dispatchers.Main) {
+                    if (notification == null) {
+                        notificationManager.cancel(ONGOING_NOTIFICATION_ID)
+                    } else {
+                        notificationManager.notify(ONGOING_NOTIFICATION_ID, notification)
+                    }
                 }
-            }.launchIn(lifecycleScope + Dispatchers.Main)
+            }.launchIn(lifecycleScope + Dispatchers.IO)
     }
 
     override fun onCreate() {

--- a/components/bsb/timer/background/impl/src/androidMain/kotlin/com/flipperdevices/bsb/timer/background/service/TimerForegroundService.kt
+++ b/components/bsb/timer/background/impl/src/androidMain/kotlin/com/flipperdevices/bsb/timer/background/service/TimerForegroundService.kt
@@ -39,7 +39,17 @@ class TimerForegroundService : LifecycleService(), LogTagProvider, TimerStateLis
     private val binder = TimerServiceBinder(delegate)
     private val notificationManager by lazy { getSystemService(NotificationManager::class.java) }
 
-    init {
+    override fun onCreate() {
+        info { "onCreate" }
+        super.onCreate()
+
+        delegate.addListener(this)
+
+        startForeground(
+            ONGOING_NOTIFICATION_ID,
+            notificationBuilder.buildStartUpNotification(applicationContext)
+        )
+
         delegate.getState()
             .onEach { state ->
                 val notification = notificationBuilder.buildNotification(
@@ -55,18 +65,6 @@ class TimerForegroundService : LifecycleService(), LogTagProvider, TimerStateLis
                     }
                 }
             }.launchIn(lifecycleScope + Dispatchers.IO)
-    }
-
-    override fun onCreate() {
-        info { "onCreate" }
-        super.onCreate()
-
-        delegate.addListener(this)
-
-        startForeground(
-            ONGOING_NOTIFICATION_ID,
-            notificationBuilder.buildStartUpNotification(applicationContext)
-        )
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {

--- a/components/bsb/timer/background/impl/src/commonMain/kotlin/com/flipperdevices/bsb/timer/background/api/CommonTimerApi.kt
+++ b/components/bsb/timer/background/impl/src/commonMain/kotlin/com/flipperdevices/bsb/timer/background/api/CommonTimerApi.kt
@@ -8,6 +8,7 @@ import com.flipperdevices.bsb.timer.statefactory.TimerStateFactory
 import com.flipperdevices.core.di.AppGraph
 import com.flipperdevices.core.ktx.common.withLock
 import com.flipperdevices.core.log.LogTagProvider
+import com.flipperdevices.core.trustedclock.TrustedClock
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
@@ -29,6 +30,7 @@ import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
 class CommonTimerApi(
     private val scope: CoroutineScope,
     private val timerStateFactory: TimerStateFactory,
+    override val trustedClock: TrustedClock,
     compositeListenersFactory: (TimerApi) -> CompositeTimerStateListener,
 ) : TimerApi, LogTagProvider {
     override val TAG = "CommonTimerApi"

--- a/components/bsb/timer/background/impl/src/commonMain/kotlin/com/flipperdevices/bsb/timer/background/api/delegates/TimerLoopJob.kt
+++ b/components/bsb/timer/background/impl/src/commonMain/kotlin/com/flipperdevices/bsb/timer/background/api/delegates/TimerLoopJob.kt
@@ -6,21 +6,18 @@ import com.flipperdevices.bsb.timer.background.model.TimerTimestamp
 import com.flipperdevices.bsb.timer.statefactory.TimerStateFactory
 import com.flipperdevices.core.ktx.common.withLock
 import com.flipperdevices.core.log.LogTagProvider
-import com.flipperdevices.core.log.info
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.measureTime
 
 class TimerLoopJob(
     scope: CoroutineScope,
@@ -34,14 +31,17 @@ class TimerLoopJob(
 
     internal fun getInternalState(): StateFlow<ControlledTimerState> = timerStateFlow.asStateFlow()
 
-    private val job = TickFlow(duration = 1000.milliseconds)
+    private val job = TickFlow(duration = 50.milliseconds)
         .filter { initialTimerTimestamp.runningOrNull?.pause == null }
         .onEach {
             mutex.withLock {
                 timerStateFlow.update { oldState ->
                     val newState = timerStateFactory.create(initialTimerTimestamp)
-                    if (newState == oldState) oldState
-                    else newState
+                    if (newState == oldState) {
+                        oldState
+                    } else {
+                        newState
+                    }
                 }
             }
         }.launchIn(scope)

--- a/components/bsb/timer/background/impl/src/commonMain/kotlin/com/flipperdevices/bsb/timer/background/api/delegates/TimerLoopJob.kt
+++ b/components/bsb/timer/background/impl/src/commonMain/kotlin/com/flipperdevices/bsb/timer/background/api/delegates/TimerLoopJob.kt
@@ -6,16 +6,21 @@ import com.flipperdevices.bsb.timer.background.model.TimerTimestamp
 import com.flipperdevices.bsb.timer.statefactory.TimerStateFactory
 import com.flipperdevices.core.ktx.common.withLock
 import com.flipperdevices.core.log.LogTagProvider
+import com.flipperdevices.core.log.info
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.measureTime
 
 class TimerLoopJob(
     scope: CoroutineScope,
@@ -29,11 +34,15 @@ class TimerLoopJob(
 
     internal fun getInternalState(): StateFlow<ControlledTimerState> = timerStateFlow.asStateFlow()
 
-    private val job = TickFlow()
+    private val job = TickFlow(duration = 1000.milliseconds)
         .filter { initialTimerTimestamp.runningOrNull?.pause == null }
         .onEach {
             mutex.withLock {
-                timerStateFlow.emit(timerStateFactory.create(initialTimerTimestamp))
+                timerStateFlow.update { oldState ->
+                    val newState = timerStateFactory.create(initialTimerTimestamp)
+                    if (newState == oldState) oldState
+                    else newState
+                }
             }
         }.launchIn(scope)
 

--- a/components/bsb/timer/state-builder/build.gradle
+++ b/components/bsb/timer/state-builder/build.gradle
@@ -13,6 +13,8 @@ commonDependencies {
     implementation(projects.components.bsb.dao.api)
     implementation(projects.components.bsb.timer.background.api)
 
+    implementation(projects.components.core.trustedClock.api)
+
     implementation(libs.kotlin.datetime)
 }
 

--- a/components/bsb/timer/state-builder/src/commonMain/kotlin/com/flipperdevices/bsb/timer/statefactory/TimerStateFactoryImpl.kt
+++ b/components/bsb/timer/state-builder/src/commonMain/kotlin/com/flipperdevices/bsb/timer/statefactory/TimerStateFactoryImpl.kt
@@ -3,12 +3,12 @@ package com.flipperdevices.bsb.timer.statefactory
 import com.flipperdevices.bsb.dao.model.TimerDuration
 import com.flipperdevices.bsb.timer.background.model.ControlledTimerState
 import com.flipperdevices.bsb.timer.background.model.TimerTimestamp
-import com.flipperdevices.bsb.timer.statefactory.iteration.datetime.TimeProvider
 import com.flipperdevices.bsb.timer.statefactory.iteration.impl.CoercedIterationBuilder
 import com.flipperdevices.bsb.timer.statefactory.iteration.impl.DefaultIterationBuilder
 import com.flipperdevices.bsb.timer.statefactory.iteration.model.IterationData
 import com.flipperdevices.bsb.timer.statefactory.iteration.model.IterationType
 import com.flipperdevices.core.di.AppGraph
+import com.flipperdevices.core.trustedclock.TrustedClock
 import kotlinx.datetime.Instant
 import me.tatarka.inject.annotations.Inject
 import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
@@ -18,7 +18,7 @@ import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
 @SingleIn(AppGraph::class)
 @ContributesBinding(AppGraph::class, TimerStateFactory::class)
 class TimerStateFactoryImpl(
-    private val timeProvider: TimeProvider
+    private val trustedClock: TrustedClock
 ) : TimerStateFactory {
 
     private fun getCurrentIteration(
@@ -155,7 +155,7 @@ class TimerStateFactoryImpl(
         if (timestamp !is TimerTimestamp.Running) {
             return ControlledTimerState.NotStarted
         }
-        val now = timestamp.pause ?: timeProvider.now()
+        val now = timestamp.pause ?: trustedClock.now()
 
         val iterations = getIterations(
             timestamp = timestamp,

--- a/components/bsb/timer/state-builder/src/commonMain/kotlin/com/flipperdevices/bsb/timer/statefactory/iteration/datetime/TimeProvider.kt
+++ b/components/bsb/timer/state-builder/src/commonMain/kotlin/com/flipperdevices/bsb/timer/statefactory/iteration/datetime/TimeProvider.kt
@@ -1,7 +1,0 @@
-package com.flipperdevices.bsb.timer.statefactory.iteration.datetime
-
-import kotlinx.datetime.Instant
-
-fun interface TimeProvider {
-    fun now(): Instant
-}

--- a/components/bsb/timer/state-builder/src/commonTest/kotlin/com/flipperdevices/bsb/timer/statefactory/iteration/TimerStateFactoryTest.kt
+++ b/components/bsb/timer/state-builder/src/commonTest/kotlin/com/flipperdevices/bsb/timer/statefactory/iteration/TimerStateFactoryTest.kt
@@ -6,7 +6,7 @@ import com.flipperdevices.bsb.dao.model.TimerSettingsId
 import com.flipperdevices.bsb.timer.background.model.ControlledTimerState
 import com.flipperdevices.bsb.timer.background.model.TimerTimestamp
 import com.flipperdevices.bsb.timer.statefactory.TimerStateFactoryImpl
-import com.flipperdevices.bsb.timer.statefactory.iteration.datetime.TimeProvider
+import com.flipperdevices.core.trustedclock.TrustedClock
 import kotlinx.datetime.Instant
 import kotlin.test.Test
 import kotlin.test.assertIs
@@ -14,7 +14,7 @@ import kotlin.time.Duration.Companion.minutes
 
 class TimerStateFactoryTest {
 
-    private val timeProvider: TimeProvider = TimeProvider { Instant.fromEpochSeconds(12345678) }
+    private val timeProvider: TrustedClock = TrustedClock { Instant.fromEpochSeconds(12345678) }
 
     @Test
     fun GIVEN_not_started_WHEN_build_THEN_not_started() {
@@ -30,6 +30,7 @@ class TimerStateFactoryTest {
             TimerTimestamp.Running(
                 lastSync = Instant.fromEpochSeconds(0),
                 start = timeProvider.now().minus(15.minutes * 15),
+                noOffsetStart = timeProvider.now(),
                 confirmNextStepClick = Instant.fromEpochSeconds(Long.MAX_VALUE),
                 settings = TimerSettings(
                     id = TimerSettingsId(-1L),
@@ -55,6 +56,7 @@ class TimerStateFactoryTest {
             TimerTimestamp.Running(
                 lastSync = Instant.fromEpochSeconds(0),
                 start = timeProvider.now().minus(15.minutes * 14),
+                noOffsetStart = timeProvider.now(),
                 confirmNextStepClick = Instant.fromEpochSeconds(0),
                 settings = TimerSettings(
                     id = TimerSettingsId(-1L),
@@ -80,6 +82,7 @@ class TimerStateFactoryTest {
             TimerTimestamp.Running(
                 lastSync = Instant.fromEpochSeconds(0),
                 start = timeProvider.now().minus(15.minutes * 14),
+                noOffsetStart = timeProvider.now(),
                 confirmNextStepClick = Instant.fromEpochSeconds(Long.MAX_VALUE),
                 settings = TimerSettings(
                     id = TimerSettingsId(-1L),

--- a/components/bsb/wear/bridge/messenger/impl/src/androidMain/kotlin/com/flipperdevices/bsb/wear/messenger/consumer/WearDataLayerRegistryMessageConsumer.kt
+++ b/components/bsb/wear/bridge/messenger/impl/src/androidMain/kotlin/com/flipperdevices/bsb/wear/messenger/consumer/WearDataLayerRegistryMessageConsumer.kt
@@ -4,11 +4,14 @@ import com.flipperdevices.bsb.wear.messenger.serializer.DecodedWearMessage
 import com.flipperdevices.bsb.wear.messenger.serializer.WearMessageSerializer
 import com.flipperdevices.core.di.AppGraph
 import com.flipperdevices.core.log.LogTagProvider
+import com.flipperdevices.core.log.TaggedLogger
 import com.flipperdevices.core.log.error
 import com.flipperdevices.core.log.info
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import me.tatarka.inject.annotations.Inject
 import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
@@ -18,7 +21,9 @@ import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
 @Inject
 @SingleIn(AppGraph::class)
 @ContributesBinding(AppGraph::class, WearMessageConsumer::class)
-class WearDataLayerRegistryMessageConsumer : WearMessageConsumer, LogTagProvider {
+class WearDataLayerRegistryMessageConsumer(
+    private val scope: CoroutineScope
+) : WearMessageConsumer, LogTagProvider {
     override val TAG: String = "WearDataLayerRegistryMessageConsumer"
     private val messageChannel = MutableSharedFlow<DecodedWearMessage<*>>()
     override val messagesFlow: Flow<DecodedWearMessage<*>> = messageChannel.asSharedFlow()
@@ -29,7 +34,9 @@ class WearDataLayerRegistryMessageConsumer : WearMessageConsumer, LogTagProvider
                 path = message.path,
                 value = message.decode(byteArray)
             )
-            runBlocking { messageChannel.emit(decodedWearMessage) }
+            scope.launch {
+                messageChannel.emit(decodedWearMessage)
+            }
         }.onFailure { throwable ->
             error(throwable) { "#consume: could not publish message: ${throwable.stackTraceToString()}" }
         }.onSuccess {

--- a/components/bsb/wear/bridge/messenger/impl/src/androidMain/kotlin/com/flipperdevices/bsb/wear/messenger/consumer/WearDataLayerRegistryMessageConsumer.kt
+++ b/components/bsb/wear/bridge/messenger/impl/src/androidMain/kotlin/com/flipperdevices/bsb/wear/messenger/consumer/WearDataLayerRegistryMessageConsumer.kt
@@ -4,7 +4,6 @@ import com.flipperdevices.bsb.wear.messenger.serializer.DecodedWearMessage
 import com.flipperdevices.bsb.wear.messenger.serializer.WearMessageSerializer
 import com.flipperdevices.core.di.AppGraph
 import com.flipperdevices.core.log.LogTagProvider
-import com.flipperdevices.core.log.TaggedLogger
 import com.flipperdevices.core.log.error
 import com.flipperdevices.core.log.info
 import kotlinx.coroutines.CoroutineScope
@@ -12,7 +11,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import me.tatarka.inject.annotations.Inject
 import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
 import software.amazon.lastmile.kotlin.inject.anvil.SingleIn

--- a/components/bsb/wear/bridge/messenger/impl/src/androidMain/kotlin/com/flipperdevices/bsb/wear/messenger/service/WearListenerService.kt
+++ b/components/bsb/wear/bridge/messenger/impl/src/androidMain/kotlin/com/flipperdevices/bsb/wear/messenger/service/WearListenerService.kt
@@ -10,14 +10,9 @@ import com.flipperdevices.core.log.error
 import com.flipperdevices.core.log.info
 import com.google.android.gms.wearable.MessageEvent
 import com.google.android.gms.wearable.WearableListenerService
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 
 class WearListenerService : WearableListenerService(), LogTagProvider {
     override val TAG: String = "StatusListenerService"
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
 
     private val wearMessengerComponent by lazy {
         ComponentHolder.component<WearDataLayerModule>()
@@ -60,6 +55,5 @@ class WearListenerService : WearableListenerService(), LogTagProvider {
     override fun onDestroy() {
         super.onDestroy()
         info { "#onDestroy DataLayerListenerService" }
-        scope.cancel()
     }
 }

--- a/components/bsb/wear/bridge/messenger/impl/src/androidMain/kotlin/com/flipperdevices/bsb/wear/messenger/util/CapabilityExt.kt
+++ b/components/bsb/wear/bridge/messenger/impl/src/androidMain/kotlin/com/flipperdevices/bsb/wear/messenger/util/CapabilityExt.kt
@@ -2,6 +2,7 @@ package com.flipperdevices.bsb.wear.messenger.util
 
 import com.flipperdevices.core.log.TaggedLogger
 import com.flipperdevices.core.log.error
+import com.flipperdevices.core.log.info
 import com.google.android.gms.common.api.ApiException
 import com.google.android.gms.wearable.CapabilityClient
 import com.google.android.gms.wearable.Node
@@ -36,9 +37,8 @@ val CapabilityClient.nodesFlow: Flow<List<Node>>
             logger.error(e) { "#nodesFlow could not find wearable api while enabling" }
         } catch (e: Throwable) {
             logger.error(e) { "#nodesFlow unhandled exception during enable" }
-        } finally {
-            close()
         }
+
 
         awaitClose {
             runBlocking {

--- a/components/bsb/wear/bridge/messenger/impl/src/androidMain/kotlin/com/flipperdevices/bsb/wear/messenger/util/CapabilityExt.kt
+++ b/components/bsb/wear/bridge/messenger/impl/src/androidMain/kotlin/com/flipperdevices/bsb/wear/messenger/util/CapabilityExt.kt
@@ -2,7 +2,6 @@ package com.flipperdevices.bsb.wear.messenger.util
 
 import com.flipperdevices.core.log.TaggedLogger
 import com.flipperdevices.core.log.error
-import com.flipperdevices.core.log.info
 import com.google.android.gms.common.api.ApiException
 import com.google.android.gms.wearable.CapabilityClient
 import com.google.android.gms.wearable.Node
@@ -38,7 +37,6 @@ val CapabilityClient.nodesFlow: Flow<List<Node>>
         } catch (e: Throwable) {
             logger.error(e) { "#nodesFlow unhandled exception during enable" }
         }
-
 
         awaitClose {
             runBlocking {

--- a/components/core/trusted-clock/api/build.gradle
+++ b/components/core/trusted-clock/api/build.gradle
@@ -1,0 +1,11 @@
+plugins {
+    id("flipper.multiplatform")
+    id("flipper.multiplatform-dependencies")
+    id("flipper.anvil-multiplatform")
+}
+
+commonDependencies {
+    implementation(projects.components.core.di)
+    implementation(projects.components.core.log)
+    implementation(libs.kotlin.datetime)
+}

--- a/components/core/trusted-clock/api/src/commonMain/kotlin/com/flipperdevices/core/trustedclock/TrustedClock.kt
+++ b/components/core/trusted-clock/api/src/commonMain/kotlin/com/flipperdevices/core/trustedclock/TrustedClock.kt
@@ -1,0 +1,7 @@
+package com.flipperdevices.core.trustedclock
+
+import kotlinx.datetime.Instant
+
+fun interface TrustedClock {
+    fun now(): Instant
+}

--- a/components/core/trusted-clock/google/build.gradle
+++ b/components/core/trusted-clock/google/build.gradle
@@ -1,0 +1,19 @@
+plugins {
+    id("flipper.multiplatform")
+    id("flipper.multiplatform-dependencies")
+    id("flipper.anvil-multiplatform")
+}
+
+commonDependencies {
+    implementation(projects.components.core.di)
+    implementation(projects.components.core.log)
+    implementation(libs.kotlin.datetime)
+    implementation(libs.kotlin.coroutines)
+    implementation(libs.kotlin.coroutines.gplayservices)
+}
+
+androidDependencies {
+    implementation(projects.components.core.trustedClock.api)
+
+    implementation(libs.gms.time)
+}

--- a/components/core/trusted-clock/google/src/androidMain/kotlin/com/flipperdevices/core/trustedclock/GoogleTrustedTimeProvider.kt
+++ b/components/core/trusted-clock/google/src/androidMain/kotlin/com/flipperdevices/core/trustedclock/GoogleTrustedTimeProvider.kt
@@ -1,0 +1,48 @@
+package com.flipperdevices.core.trustedclock
+
+import android.content.Context
+import com.flipperdevices.core.di.AppGraph
+import com.flipperdevices.core.log.LogTagProvider
+import com.flipperdevices.core.log.error
+import com.google.android.gms.time.TrustedTime
+import com.google.android.gms.time.TrustedTimeClient
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.tasks.await
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlinx.datetime.toKotlinInstant
+import me.tatarka.inject.annotations.Inject
+import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
+import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
+
+@Inject
+@SingleIn(AppGraph::class)
+@ContributesBinding(AppGraph::class, TrustedClock::class)
+class GoogleTrustedTimeProvider(
+    private val scope: CoroutineScope,
+    private val context: Context
+) : TrustedClock, LogTagProvider {
+    override val TAG: String = "GoogleTrustedTimeProvider"
+
+    private val trustedClientFlow = callbackFlow {
+        val clientTask = TrustedTime.createClient(context)
+        val client = runCatching { clientTask.await() }
+            .onFailure { error(it) { "#trustedClientFlow could not get client" } }
+            .getOrNull()
+        send(client)
+        awaitClose {
+            client?.dispose()
+        }
+    }.stateIn(scope, SharingStarted.Eagerly, null)
+
+    override fun now(): Instant {
+        val trustedInstant = trustedClientFlow.value
+            ?.computeCurrentInstant()
+            ?.toKotlinInstant()
+        return trustedInstant ?: Clock.System.now()
+    }
+}

--- a/components/core/trusted-clock/kotlinx/build.gradle
+++ b/components/core/trusted-clock/kotlinx/build.gradle
@@ -1,0 +1,13 @@
+plugins {
+    id("flipper.multiplatform")
+    id("flipper.multiplatform-dependencies")
+    id("flipper.anvil-multiplatform")
+}
+
+commonDependencies {
+    implementation(projects.components.core.di)
+    implementation(projects.components.core.log)
+    implementation(libs.kotlin.datetime)
+
+    implementation(projects.components.core.trustedClock.api)
+}

--- a/components/core/trusted-clock/kotlinx/src/commonMain/kotlin/com/flipperdevices/core/trustedclock/KotlinxTrustedClock.kt
+++ b/components/core/trusted-clock/kotlinx/src/commonMain/kotlin/com/flipperdevices/core/trustedclock/KotlinxTrustedClock.kt
@@ -1,14 +1,16 @@
-package com.flipperdevices.bsb.timer.statefactory.iteration.datetime
+package com.flipperdevices.core.trustedclock
 
 import com.flipperdevices.core.di.AppGraph
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import me.tatarka.inject.annotations.Inject
 import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
+import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
 
 @Inject
-@ContributesBinding(AppGraph::class, TimeProvider::class)
-class KotlinxDatetimeTimeProvider : TimeProvider {
+@SingleIn(AppGraph::class)
+@ContributesBinding(AppGraph::class, TrustedClock::class)
+class KotlinxTrustedClock : TrustedClock {
     override fun now(): Instant {
         return Clock.System.now()
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,6 +55,7 @@ compose-wear-preview = "1.0.0" # https://mvnrepository.com/artifact/androidx.wea
 haze = "1.5.2"
 sentry-runtime = "8.6.0" # https://github.com/getsentry/sentry-java/releases
 sentry-gradle = "5.3.0" # https://github.com/getsentry/sentry-android-gradle-plugin/releases
+gms-time = "16.0.1" # https://developers.google.com/location-context/time
 
 [libraries]
 android-gradle = { module = "com.android.tools.build:gradle", version.ref = "agp" }
@@ -149,6 +150,7 @@ wear-gms = { module = "com.google.android.gms:play-services-wearable", version.r
 wear-interaction-phone = { module = "androidx.wear:wear-phone-interactions", version.ref = "wear-interaction-phone" }
 wear-interaction-remote = { module = "androidx.wear:wear-remote-interactions", version.ref = "wear-interaction-remote" }
 wear-ongoing = { module = "androidx.wear:wear-ongoing", version.ref = "wear-ongoing" }
+
 # wear - ui
 compose-wear-material = { module = "androidx.wear.compose:compose-material", version.ref = "compose-wear" }
 compose-wear-foundation = { module = "androidx.wear.compose:compose-foundation", version.ref = "compose-wear" }
@@ -157,6 +159,7 @@ horologist-layout = { module = "com.google.android.horologist:horologist-compose
 google-horologist-datalayer = { module = "com.google.android.horologist:horologist-datalayer", version.ref = "horologist" }
 google-horologist-datalayer-watch = { module = "com.google.android.horologist:horologist-datalayer-watch", version.ref = "horologist" }
 google-horologist-datalayer-phone = { module = "com.google.android.horologist:horologist-datalayer-phone", version.ref = "horologist" }
+gms-time = { module = "com.google.android.gms:play-services-time", version.ref = "gms-time" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/instances/bsb-wear/build.gradle.kts
+++ b/instances/bsb-wear/build.gradle.kts
@@ -38,6 +38,7 @@ commonDependencies {
     implementation(projects.components.core.ui.text)
     implementation(projects.components.core.ui.autosizetext)
     implementation(projects.components.core.activityholder)
+    implementation(projects.components.core.trustedClock.api)
     implementation(projects.components.bsb.deeplink.api)
     implementation(projects.components.bsb.deeplink.impl)
     implementation(projects.components.bsb.core.theme)
@@ -99,6 +100,8 @@ dependencies {
 
     implementation(libs.google.horologist.datalayer)
     implementation(libs.google.horologist.datalayer.watch)
+
+    implementation(projects.components.core.trustedClock.google)
 }
 
 dependencies {

--- a/instances/bsb-wear/src/androidMain/kotlin/com/flipperdevices/bsbwearable/root/api/RootDecomposeComponentImpl.kt
+++ b/instances/bsb-wear/src/androidMain/kotlin/com/flipperdevices/bsbwearable/root/api/RootDecomposeComponentImpl.kt
@@ -18,11 +18,14 @@ import com.flipperdevices.bsbwearable.composable.SwipeToDismissBox
 import com.flipperdevices.bsbwearable.finish.api.FinishScreenDecomposeComponent
 import com.flipperdevices.bsbwearable.root.api.model.RootNavigationConfig
 import com.flipperdevices.core.di.AppGraph
+import com.flipperdevices.core.ktx.common.FlipperDispatchers
 import com.flipperdevices.ui.decompose.DecomposeComponent
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.withContext
 import me.tatarka.inject.annotations.Assisted
 import me.tatarka.inject.annotations.Inject
 import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
@@ -89,8 +92,12 @@ class RootDecomposeComponentImpl(
                     }
                 }
             }
-            .onEach { navigation.replaceAll(it) }
-            .launchIn(coroutineScope())
+            .onEach {
+                withContext(Dispatchers.Main) {
+                    navigation.replaceAll(it)
+                }
+            }
+            .launchIn(coroutineScope(FlipperDispatchers.default))
     }
 
     private fun child(

--- a/instances/bsb/build.gradle.kts
+++ b/instances/bsb/build.gradle.kts
@@ -69,14 +69,17 @@ kotlin {
                 implementation(libs.google.horologist.datalayer)
                 implementation(libs.google.horologist.datalayer.phone)
                 implementation(projects.components.bsb.timer.syncservice.firebase)
+                implementation(projects.components.core.trustedClock.google)
             } else {
                 implementation(projects.components.bsb.wear.bridge.syncservice.api)
                 implementation(projects.components.bsb.wear.bridge.syncservice.noop)
                 implementation(projects.components.bsb.timer.syncservice.noop)
+                implementation(projects.components.core.trustedClock.kotlinx)
             }
         }
         commonMain.dependencies {
             implementation(projects.components.core.focusDisplay)
+            implementation(projects.components.core.trustedClock.api)
 
             implementation(compose.runtime)
             implementation(compose.foundation)
@@ -103,6 +106,7 @@ kotlin {
             implementation(projects.components.core.ui.timeline)
             implementation(projects.components.bsb.analytics.metric.noop)
             implementation(projects.components.bsb.timer.syncservice.socket)
+            implementation(projects.components.core.trustedClock.kotlinx)
         }
         iosMain.dependencies {
             api(libs.decompose)
@@ -113,6 +117,7 @@ kotlin {
             implementation(libs.settings.observable)
             implementation(projects.components.bsb.analytics.metric.noop)
             implementation(projects.components.bsb.timer.syncservice.noop)
+            implementation(projects.components.core.trustedClock.kotlinx)
         }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -57,6 +57,9 @@ include(
     ":components:core:ui:video",
     ":components:core:ui:autosizetext",
     ":components:core:ui:text",
+    ":components:core:trusted-clock:api",
+    ":components:core:trusted-clock:google",
+    ":components:core:trusted-clock:kotlinx",
 
     ":components:bsb:core:theme",
     ":components:bsb:core:res",


### PR DESCRIPTION
## Summary
Android and wearos has different Clock.System.now(), which can lead to different TimerTimestamps state results
## Changes
- Add `TrustedClock` for Google impl on android and Kotlinx.datetime on other platforms
- Reduce tickflow to 50.milliseconds
- Fix runBlockings, which could block wearOS app